### PR TITLE
Fix build failure by adding autoprefixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "react-dom": "^18.2.0",
     "next": "13.4.0",
     "framer-motion": "^7.6.7",
-    "tailwindcss": "^3.3.2"
+    "tailwindcss": "^3.3.2",
+    "autoprefixer": "^10.4.14"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- add `autoprefixer` to project dependencies
- ignore `node_modules`, `.next`, and `package-lock.json`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684980e88b74832daa2c2cbf1a1df323