### PR TITLE
Fix layout overflow on landing page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -37,7 +37,7 @@ const modules = [
 
 export default function LandingPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-900 via-indigo-800 to-gray-900 text-white font-sans px-6 py-12">
+    <div className="min-h-screen bg-gradient-to-br from-purple-900 via-indigo-800 to-gray-900 text-white font-sans px-6 sm:px-10 lg:px-20 py-12 max-w-screen-xl mx-auto box-border">
       <header className="text-center mb-12">
         <motion.h1
           className="text-5xl font-bold tracking-wide neon-text drop-shadow-lg"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,3 +7,7 @@ body {
   background: linear-gradient(135deg, #340058, #561776 45%, #b83280);
   color: #ffffff;
 }
+
+* {
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- set a max width for the main container and add responsive padding
- ensure all elements use `border-box` sizing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68498b4450a0832da340be32f72c907e